### PR TITLE
update readme to include compatible driver version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ About
 
 This sample code implement procedures to read values from BME280 sensor (pressure, temperature, humidity) via ESP-IDF's I2C master driver. It supports both normal mode and forced mode described in `Bosch's BME280 datasheet`_, Section 3.3 Sensor modes, Page 12.
 
+This code is not compatible with the newest Bosch driver version. The last version that works correctly is v2.0.5, commit cf40d00_.
+
 ----------
 For local setup
 ----------
@@ -20,3 +22,4 @@ Don't forget to connect SDO to Vio too. It maps device address to 0x77 (not 0x76
 .. _main.c: https://github.com/yanbe/bme280-esp-idf-i2c/blob/master/main/main.c
 .. _ESP32 datasheet: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
 .. _Bosch's BME280 datasheet: https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf
+.. _cf40d00: https://github.com/BoschSensortec/BME280_driver/tree/cf40d00b0b5139e287b670881c433c0041d98d9f


### PR DESCRIPTION
The link in the 'components' folder did not link correctly for me and I spent quite some time wondering why it didn't work. I've updated the readme with a note and a link to the correct driver version to alert others.